### PR TITLE
Fix rvalid demux from LWI. Now it accounts for the gnt

### DIFF
--- a/hw/rtl/cgra_rcs.sv
+++ b/hw/rtl/cgra_rcs.sv
@@ -147,7 +147,7 @@ module cgra_rcs
         rvalid_demux[j] = '0;
         // for each row
         for (int k=0; k<N_ROW; k++) begin
-          if (data_req_rvalid_mask[j][k] == 1'b1 && data_wen_s[k][j] == 1'b1 && data_rvalid_i[j] == 1'b1 && (gnt_demux[j][k] == 1'b1 || gnt_mask[j][k] == 1'b0)) begin
+          if (data_req_rvalid_mask[j][k] == 1'b1 && data_wen_s[k][j] == 1'b1 && data_rvalid_i[j] == 1'b1 && gnt_mask[j][k] == 1'b0) begin
             rvalid_demux[j][k] = 1'b1;
             break;
           end

--- a/hw/rtl/cgra_rcs.sv
+++ b/hw/rtl/cgra_rcs.sv
@@ -147,7 +147,7 @@ module cgra_rcs
         rvalid_demux[j] = '0;
         // for each row
         for (int k=0; k<N_ROW; k++) begin
-          if (data_req_rvalid_mask[j][k] == 1'b1 && data_wen_s[k][j] == 1'b1 && data_rvalid_i[j] == 1'b1) begin
+          if (data_req_rvalid_mask[j][k] == 1'b1 && data_wen_s[k][j] == 1'b1 && data_rvalid_i[j] == 1'b1 && (gnt_demux[j][k] == 1'b1 || gnt_mask[j][k] == 1'b0)) begin
             rvalid_demux[j][k] = 1'b1;
             break;
           end


### PR DESCRIPTION
When used in HEEPsilon, there is an error when granting the signals for a column where SWD happens before an LWD in the same time step. The bus gives a read-valid signal even with a write enable. In this fix, the read-valid demux logic also takes into account that the PE requesting a read is being granted (or has been) before allowing it to read